### PR TITLE
fix: use-sync-external-store/shim import in ESM

### DIFF
--- a/src/lib/hooks/useUrl.ts
+++ b/src/lib/hooks/useUrl.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-globals */
 import { useCallback, useEffect, useRef } from 'react';
 
-import { useSyncExternalStore } from 'use-sync-external-store/shim';
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js';
 
 import NotificationStore from '../store/NotificationStore';
 import { initiateNavigationEvents } from '../utils/initiateNavigationEvents';


### PR DESCRIPTION
ESM requires providing the file extension when importing - [source](https://nodejs.org/api/esm.html#mandatory-file-extensions)

When importing the package as is, an error is thrown:

> The request 'use-sync-external-store/shim' failed to resolve only because it was resolved as fully specified
(probably because the origin is a '*.mjs' file or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.